### PR TITLE
Avoid toDate to support strftime

### DIFF
--- a/classes/Feed.php
+++ b/classes/Feed.php
@@ -90,7 +90,7 @@ class Feed
             $options['modified'] = $items->first()->modified('r', 'date');
         } else {
             $f = $options['datefield'];
-            $options['modified'] = $items->first()->{$f}()->toDate('r', 'date');
+            $options['modified'] = date('r', $items->first()->{$f}()->toTimestamp());
         }
 
         return $options;

--- a/snippets/feed/json.php
+++ b/snippets/feed/json.php
@@ -8,7 +8,7 @@
             'url'            => $item->url(),
             'title'          => $item->title()->value(),
             'content_html'   => $item->{$textfield}()->kirbytext()->value(),
-            'date_published' => $item->{$datefield}()->toDate('c'),
+            'date_published' => date('c', $item->{$datefield}()->toTimestamp()),
             'date_modified'  => $item->modified('Y-m-d\TH:i:sP', 'date'),
         ];
     }

--- a/snippets/feed/rss.php
+++ b/snippets/feed/rss.php
@@ -18,7 +18,7 @@ echo '<?xml version="1.0" encoding="utf-8"?>';
       <title><?php echo Xml::encode($item->title()) ?></title>
       <link><?php echo Xml::encode($item->url()) ?></link>
       <guid><?php echo Xml::encode($item->id()) ?></guid>
-      <pubDate><?php echo $datefield == 'modified' ? $item->modified('r', 'date') : $item->{$datefield}()->toDate('r') ?></pubDate>
+      <pubDate><?php echo $datefield == 'modified' ? $item->modified('r', 'date') : date('r', $item->{$datefield}()->toTimestamp()) ?></pubDate>
       <description><![CDATA[<?php echo $item->{$textfield}()->kirbytext() ?>]]></description>
     </item>
     <?php endforeach ?>


### PR DESCRIPTION
Replace `toDate` by `date` because `toDate` does not have a second parameter that allows to force the usage of the `date` method instead of `strftime` when you set `c::set('date.handler', 'strftime');` in your Kirby config.

Fixes #9 