### PR TITLE
Readme: Add explanation on mime types

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ $feed = site()->index()->listed()
 
 | bnomei.feed.              | Default        | Description               |            
 |---------------------------|----------------|---------------------------|
-| mime | `null` | to autodetect json or rss-xml otherwise enforce output with a certain MIME type (one of the extensions defined in Kirby's [Mime class](https://github.com/k-next/kirby/blob/master/src/Toolkit/Mime.php), e.g. value `xml` to enforce `application/xml`) |
+| mime | `null` | to autodetect json or rss-xml otherwise enforce output with a certain MIME type (one of the extensions defined in Kirby's [Mime class](https://github.com/k-next/kirby/blob/master/src/Toolkit/Mime.php), e.g. value `xml` to enforce `text/xml`) |
 | expires |`60*24*7` | in minutes |
 
 > The plugin will automatically devalidate the cache if any of the Page-Objects were modified.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ $feed = site()->index()->listed()
 
 | bnomei.feed.              | Default        | Description               |            
 |---------------------------|----------------|---------------------------|
-| mime | `null` | to autodetect json or rss-xml otherwise enforce output with a certain [mime type](https://github.com/k-next/kirby/blob/master/src/Toolkit/Mime.php) |
+| mime | `null` | to autodetect json or rss-xml otherwise enforce output with a certain MIME type (one of the extensions defined in Kirby's [Mime class](https://github.com/k-next/kirby/blob/master/src/Toolkit/Mime.php), e.g. value `xml` to enforce `application/xml`) |
 | expires |`60*24*7` | in minutes |
 
 > The plugin will automatically devalidate the cache if any of the Page-Objects were modified.


### PR DESCRIPTION
Adding a short explanation that the `mime` setting expects an extension, not a complete header string; via https://forum.getkirby.com/t/kirby3-feed-where-to-add-a-xsl-file/23228