### PR TITLE
Add homepage link for Kirby panel view

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "type": "kirby-plugin",
   "version": "5.0.2",
   "description": "Generate a Atom/JSON/RSS-Feed and XML-Sitemap from Pages-Collections",
+  "homepage": "https://github.com/bnomei/kirby3-feed",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
Setting the homepage link in the composer.json so it makes the plugin name clickable in the Kirby Plugin listing. I'm not sure if this is intentionally not set, in that case ignore this of course.

Before:
<img width="1292" height="410" alt="CleanShot 2025-07-16 at 20 27 27@2x" src="https://github.com/user-attachments/assets/ae81c97a-29a6-407e-8a6f-1a0cc36fe107" />

After:
<img width="1054" height="402" alt="CleanShot 2025-07-16 at 20 27 07@2x" src="https://github.com/user-attachments/assets/3328f63c-20d3-4d69-a0c6-11670642c9f3" />
